### PR TITLE
Draft: multi-series

### DIFF
--- a/src/YieldSpaceAMO.sol
+++ b/src/YieldSpaceAMO.sol
@@ -292,11 +292,11 @@ contract YieldSpaceAMO is Owned {
         Series storage _series = series[seriesId];
         require (_series.vaultId != bytes12(0), "Series not found");
 
-        //Transfer pool tokens into the pool. Burn pool tokens, with the fyFRAX going into the Ladle.
-        //Instruct the Ladle to repay as much debt as fyFRAX it received, and withdraw the same amount of collateral.
+        //Transfer pool tokens into the pool. Burn pool tokens, with the fyFRAX going into the fyFRAX contract.
+        //Instruct the Ladle to repay as much debt as fyFRAX from the burn, and withdraw the same amount of collateral.
         _series.pool.transfer(address(_series.pool), _poolAmount);
-        _series.pool.burn(address(this), address(ladle), _minRatio, _maxRatio);
-        ladle.repayFromLadle(_series.vaultId, address(this));
+        (,, uint256 fyFraxAmount) = _series.pool.burn(address(this), _series.fyToken, _minRatio, _maxRatio);
+        ladle.pour(_series.vaultId, address(this), -safeToInt(fyFraxAmount), -safeToInt(fyFraxAmount));
         emit liquidityRemoved(_poolAmount);
     }
 

--- a/src/YieldSpaceAMO.sol
+++ b/src/YieldSpaceAMO.sol
@@ -38,7 +38,6 @@ library DataTypes {
 
 interface ILadle {
     function pour(bytes12 vaultId_, address to, int128 ink, int128 art) external payable;
-    function repayFromLadle(bytes12 vaultId_, address to) external payable returns (uint256 repaid);
     function build(bytes6 seriesId, bytes6 ilkId, uint8 salt) external returns (bytes12 vaultId, DataTypes.Vault memory vault);
     function cauldron() external view returns (ICauldron);
 }

--- a/src/YieldSpaceAMO.sol
+++ b/src/YieldSpaceAMO.sol
@@ -19,7 +19,7 @@ pragma solidity ^0.8.0;
 // Dennis: https://github.com/denett
 
 import "./Frax/IFrax.sol";
-import "./Frax/IFraxAmoMinter.sol";
+import "./Frax/IFraxAMOMinter.sol";
 import "./utils/Owned.sol";
 import "./Yield/IFYToken.sol";
 import "./Yield/IPool.sol";
@@ -48,6 +48,16 @@ interface ICauldron {
 }
 
 contract YieldSpaceAMO is Owned {
+    /* =========== CONSTANTS =========== */
+    bytes6 public constant FRAX_ILK_ID = 0x3138;
+
+    /* =========== DATA TYPES =========== */
+    struct Series {
+        bytes12 vaultId; /// @notice The AMO's debt & collateral record for this series
+        IFYToken fyToken;
+        IPool pool;
+    }
+
     /* =========== STATE VARIABLES =========== */
     
     // Frax
@@ -57,12 +67,11 @@ contract YieldSpaceAMO is Owned {
     address public custodian_address;
 
     // Yield Protocol
-    IFYToken private immutable fyFRAX;
-    ILadle private immutable ladle;
-    IPool private immutable pool;
-    ICauldron private immutable cauldron;
+    ILadle public immutable ladle;
+    ICauldron public immutable cauldron;
     address public immutable fraxJoin;
-    bytes12 public immutable vaultId; /// @notice The AMO's debt & collateral record
+    mapping(bytes6 => Series) public series;
+    bytes6[] public seriesIterator;
 
     // AMO
     uint256 public currentAMOmintedFRAX; /// @notice The amount of FRAX tokens minted by the AMO
@@ -75,41 +84,35 @@ contract YieldSpaceAMO is Owned {
         address _owner_address,
         address _amo_minter_address,
         address _yield_ladle,
-        address _target_fyFrax_pool,
-        address _yield_frax_join,
-        bytes6 _seriesId
+        address _yield_frax_join
     ) Owned(_owner_address) {
         FRAX = IFrax(0x853d955aCEf822Db058eb8505911ED77F175b99e);
         amo_minter = IFraxAMOMinter(_amo_minter_address);
         timelock_address = amo_minter.timelock_address();
 
         ladle = ILadle (_yield_ladle);
-        pool = IPool(_target_fyFrax_pool);
-        fyFRAX = IFYToken(pool.fyToken());
         cauldron = ICauldron(ladle.cauldron());
         fraxJoin = _yield_frax_join;
 
         currentAMOmintedFRAX = 0;
         currentAMOmintedFyFRAX = 0;
         fraxLiquidityAdded = 0;
-
-        (vaultId,) = ladle.build(_seriesId, "0x3138", 0); //0x3138 is IlkID for Frax
     }
 
     /* ============== MODIFIERS ============== */
     modifier onlyByOwnGov() {
-        require(msg.sender == timelock_address || msg.sender == owner, "Not owner or timelock");
+        require (msg.sender == timelock_address || msg.sender == owner, "Not owner or timelock");
         _;
     }
 
     modifier onlyByMinter() {
-        require(msg.sender == address(amo_minter), "Not minter");
+        require (msg.sender == address(amo_minter), "Not minter");
         _;
     }
 
      /* ============== UTILITY =============== */
     function safeToInt(uint256 amount) private pure returns(int128){
-        require(amount < 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF, "integer casting unsafe"); //max uint in 127 bits
+        require (amount < 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF, "integer casting unsafe"); //max uint in 127 bits
         return int128(uint128(amount));
     }
 
@@ -119,13 +122,16 @@ contract YieldSpaceAMO is Owned {
     //     return (circulatingAMOMintedFyFrax() - currentRaisedFrax()) / (currentRaisedFrax() * /*timeremaining*/; //TODO pos/neg
     // }
 
-    function showAllocations() public view returns (uint256[6] memory return_arr) {
+    function showAllocations(bytes6 seriesId) public view returns (uint256[5] memory return_arr) {
+        Series storage _series = series[seriesId];
+        require (_series.vaultId != bytes12(0), "Series not found");
+
         uint256 frax_in_contract = FRAX.balanceOf(address(this));
-        uint256 frax_as_collateral = uint256(cauldron.balances(vaultId).ink);
-        uint256 frax_in_LP = FRAX.balanceOf(address(pool)) * pool.balanceOf(address(this)) / pool.totalSupply();
-        uint256 fyFrax_in_contract = fyFRAX.balanceOf(address(this));
-        uint256 fyFrax_in_LP = fyFRAX.balanceOf(address(pool)) * pool.balanceOf(address(this)) / pool.totalSupply();
-        uint256 LP_owned = pool.balanceOf(address(this));
+        uint256 frax_as_collateral = uint256(cauldron.balances(_series.vaultId).ink);
+        uint256 frax_in_LP = FRAX.balanceOf(address(_series.pool)) * _series.pool.balanceOf(address(this)) / _series.pool.totalSupply();
+        uint256 fyFrax_in_contract = _series.fyToken.balanceOf(address(this));
+        uint256 fyFrax_in_LP = _series.fyToken.balanceOf(address(_series.pool)) * _series.pool.balanceOf(address(this)) / _series.pool.totalSupply();
+        uint256 LP_owned = _series.pool.balanceOf(address(this));
         return [
             frax_in_contract,       // [0] Unallocated Frax
             frax_as_collateral,     // [1] Frax being used as collateral to borrow fyFrax                     
@@ -136,22 +142,22 @@ contract YieldSpaceAMO is Owned {
         ];
     }
 
-    function currFraxInAMOLP() public view returns (uint256) {
-        uint256[6] memory arr = showAllocations();
+    function currFraxInAMOLP(bytes6 seriesId) public view returns (uint256) {
+        uint256[6] memory arr = showAllocations(seriesId);
         return arr[2];
         // return FRAX.balanceOf(address(pool)) * pool.balanceOf(address(this)) / pool.totalSupply();
     }
     
-    function currFyFraxInAMOLP() public view returns (uint256) {
-        uint256[6] memory arr = showAllocations();
+    function currFyFraxInAMOLP(bytes6 seriesId) public view returns (uint256) {
+        uint256[6] memory arr = showAllocations(seriesId);
         return arr[4];
         // return fyFRAX.balanceOf(address(pool)) * pool.balanceOf(address(this)) / pool.totalSupply();
     }
 
     /// @return raisedFrax The Frax fundraised by the AMO
     /// @return isNegative True if currFrax should be flipped in sign, ie the LP has less Frax than it began with
-    function currentRaisedFrax() public view returns (uint256 raisedFrax, bool isNegative) {
-        uint256 fraxInLP = currFraxInAMOLP();
+    function currentRaisedFrax(bytes6 seriesId) public view returns (uint256 raisedFrax, bool isNegative) {
+        uint256 fraxInLP = currFraxInAMOLP(seriesId);
         if (fraxInLP >= fraxLiquidityAdded) { //Frax has entered the AMO's LP
             return (fraxInLP - fraxLiquidityAdded, false);
         } else { //Frax has left the AMO's LP
@@ -161,8 +167,8 @@ contract YieldSpaceAMO is Owned {
 
     /// @notice returns the current amount of FRAX that the protocol must pay out on maturity of circulating fyFRAX in the open market
     /// @notice signed return value
-    function circulatingAMOMintedFyFrax() public view returns (uint256 circulatingFyFrax, bool isNegative) {
-        uint256 fyFraxInLP = currFyFraxInAMOLP();
+    function circulatingAMOMintedFyFrax(bytes6 seriesId) public view returns (uint256 circulatingFyFrax, bool isNegative) {
+        uint256 fyFraxInLP = currFyFraxInAMOLP(seriesId);
         if (fyFraxLiquidityAdded >= fyFraxInLP) { //AMO minted fyFrax has left the LP
             return (fyFraxLiquidityAdded - fyFraxInLP, false);
         } else { //non-AMO minted fyFrax has entered the LP
@@ -185,59 +191,112 @@ contract YieldSpaceAMO is Owned {
     }
     
     /* ========= RESTRICTED FUNCTIONS ======== */
+    /// @notice register a new series in the AMO
+    function addSeries(bytes6 seriesId, IFYToken fyToken, IPool pool) public onlyByOwnGov {
+        require (ladle.pools(seriesId) == address(pool), "Mismatched pool");
+        require (cauldron.series(seriesId).fyToken == address(fyToken), "Mismatched fyToken");
+
+        (bytes12 vaultId,) = ladle.build(seriesId, FRAX_ILK_ID, 0);
+        series[seriesId] = Series({
+            vaultId : vaultId,
+            fyToken : fyToken,
+            pool : pool
+        });
+
+        seriesIterator.push(seriesId);
+    }
+
+    /// @notice remove a new series in the AMO, to keep gas costs in place
+    function removeSeries(bytes6 seriesId) public onlyByOwnGov {
+        Series storage _series = series[seriesId];
+        require (_series.vaultId != bytes12(0), "Series not found");
+        require (_series.fyToken.balanceOf(address(this)) == 0, "Outstanding fyToken balance");
+        require (_series.pool.balanceOf(address(this)) == 0, "Outstanding pool balance");
+        delete series[seriesId];
+
+        // Remove the seriesId from the iterator, by replacing for the tail and popping.
+        uint256 activeSeries = seriesIterator.length;
+        for (uint256 s; s < activeSeries; ++s) {
+            if (seriesId == seriesIterator[s]) {
+                if (s < activeSeries - 1) {
+                    seriesIterator[s] = seriesIterator[activeSeries - 1];
+                }
+                seriesIterator.pop();
+            }
+        }
+    }
+
     /// @notice mint fyFrax using FRAX as collateral 1:1 Frax to fyFrax
-    function mintFyFrax(uint128 _amount) public onlyByOwnGov {
+    function mintFyFrax(bytes6 seriesId, uint128 _amount) public onlyByOwnGov {
+        Series storage _series = series[seriesId];
+        require (_series.vaultId != bytes12(0), "Series not found");
+
         //Transfer FRAX to the FRAX Join, add it as collateral, and borrow.
         int128 intAmount = safeToInt(_amount);
         FRAX.transfer(fraxJoin, _amount);
-        ladle.pour(vaultId, address(this), intAmount, intAmount);
+        ladle.pour(_series.vaultId, address(this), intAmount, intAmount);
     }
 
     /// @notice burn fyFrax to redeem FRAX collateral
-    function burnFyFrax() public onlyByOwnGov { 
+    function burnFyFrax(bytes6 seriesId) public onlyByOwnGov { 
+        Series storage _series = series[seriesId];
+        require (_series.vaultId != bytes12(0), "Series not found");
+
         //Transfer fyFRAX to the fyFRAX contract, repay debt, and withdraw FRAX collateral.
-        uint256 fyFraxAmount = fyFRAX.balanceOf(address(this));
-        fyFRAX.transfer(address(fyFRAX), fyFraxAmount);
-        ladle.pour(vaultId, address(this), -safeToInt(fyFraxAmount), -safeToInt(fyFraxAmount));
+        uint256 fyFraxAmount = _series.fyToken.balanceOf(address(this));
+        _series.fyToken.transfer(address(_series.fyToken), fyFraxAmount);
+        ladle.pour(_series.vaultId, address(this), -safeToInt(fyFraxAmount), -safeToInt(fyFraxAmount));
     }
 
     /// @notice mint new fyFrax to sell into the AMM to push up rates 
-    function increaseRates(uint128 _fraxAmount, uint128 _minFraxReceived) public onlyByOwnGov {
+    function increaseRates(bytes6 seriesId, uint128 _fraxAmount, uint128 _minFraxReceived) public onlyByOwnGov {
+        Series storage _series = series[seriesId];
+        require (_series.vaultId != bytes12(0), "Series not found");
+
         //Mint fyFRAX into the pool, and sell it.
         uint256 fyFraxAmount = _fraxAmount;
         FRAX.transfer(fraxJoin, _fraxAmount);
-        ladle.pour(vaultId, address(pool), safeToInt(_fraxAmount), safeToInt(fyFraxAmount));
-        pool.sellFYToken(address(this), _minFraxReceived);
+        ladle.pour(_series.vaultId, address(_series.pool), safeToInt(_fraxAmount), safeToInt(fyFraxAmount));
+        _series.pool.sellFYToken(address(this), _minFraxReceived);
         emit ratesIncreased(_fraxAmount, _minFraxReceived);
     }
 
     /// @notice buy fyFrax from the AMO and burn it to push down rates
-    function decreaseRates(uint128 _fraxAmount, uint128 _minFyFraxReceived) public onlyByOwnGov {
+    function decreaseRates(bytes6 seriesId, uint128 _fraxAmount, uint128 _minFyFraxReceived) public onlyByOwnGov {
+        Series storage _series = series[seriesId];
+        require (_series.vaultId != bytes12(0), "Series not found");
+
         //Transfer FRAX into the pool, sell it for fyFRAX into the fyFRAX contract, repay debt and withdraw FRAX collateral.
-        FRAX.transfer(address(pool), _fraxAmount);
-        uint256 fyFraxReceived = pool.sellBase(address(fyFRAX), _minFyFraxReceived);
+        FRAX.transfer(address(_series.pool), _fraxAmount);
+        uint256 fyFraxReceived = _series.pool.sellBase(address(_series.fyToken), _minFyFraxReceived);
         uint256 fraxCollat = fyFraxReceived;
-        ladle.pour(vaultId, address(this), -safeToInt(fraxCollat), -safeToInt(fyFraxReceived));
+        ladle.pour(_series.vaultId, address(this), -safeToInt(fraxCollat), -safeToInt(fyFraxReceived));
         emit ratesDecreased(_fraxAmount, _minFyFraxReceived);
     }
 
     /// @notice mint fyFrax tokens, pair with FRAX and provide liquidity
-    function addLiquidityToAMM(uint128 _fraxAmount, uint128 _fyFraxAmount, uint256 _minRatio, uint256 _maxRatio) public onlyByOwnGov {
+    function addLiquidityToAMM(bytes6 seriesId, uint128 _fraxAmount, uint128 _fyFraxAmount, uint256 _minRatio, uint256 _maxRatio) public onlyByOwnGov {
+        Series storage _series = series[seriesId];
+        require (_series.vaultId != bytes12(0), "Series not found");
+
         //Transfer FRAX into the pool. Transfer FRAX into the FRAX Join. Borrow fyFRAX into the pool. Add liquidity.
         FRAX.transfer(fraxJoin, _fyFraxAmount);
-        FRAX.transfer(address(pool), _fraxAmount);
-        ladle.pour(vaultId, address(pool), safeToInt(_fyFraxAmount), safeToInt(_fyFraxAmount));
-        pool.mint(address(this), address(this), _minRatio, _maxRatio); //Second param receives remainder
+        FRAX.transfer(address(_series.pool), _fraxAmount);
+        ladle.pour(_series.vaultId, address(_series.pool), safeToInt(_fyFraxAmount), safeToInt(_fyFraxAmount));
+        _series.pool.mint(address(this), address(this), _minRatio, _maxRatio); //Second param receives remainder
         emit liquidityAdded(_fraxAmount, _fyFraxAmount);
     }
 
     /// @notice remove liquidity and burn fyTokens
-    function removeLiquidityFromAMM(uint256 _poolAmount, uint256 _minRatio, uint256 _maxRatio) public onlyByOwnGov {
+    function removeLiquidityFromAMM(bytes6 seriesId, uint256 _poolAmount, uint256 _minRatio, uint256 _maxRatio) public onlyByOwnGov {
+        Series storage _series = series[seriesId];
+        require (_series.vaultId != bytes12(0), "Series not found");
+
         //Transfer pool tokens into the pool. Burn pool tokens, with the fyFRAX going into the Ladle.
         //Instruct the Ladle to repay as much debt as fyFRAX it received, and withdraw the same amount of collateral.
-        pool.transfer(address(pool), _poolAmount);
-        pool.burn(address(this), address(ladle), _minRatio, _maxRatio);
-        ladle.repayFromLadle(vaultId, address(this));
+        _series.pool.transfer(address(_series.pool), _poolAmount);
+        _series.pool.burn(address(this), address(ladle), _minRatio, _maxRatio);
+        ladle.repayFromLadle(_series.vaultId, address(this));
         emit liquidityRemoved(_poolAmount);
     }
 
@@ -249,7 +308,7 @@ contract YieldSpaceAMO is Owned {
         timelock_address = amo_minter.timelock_address();
 
         // Make sure the new addresses are not address(0)
-        require(timelock_address != address(0), "Invalid timelock");
+        require (timelock_address != address(0), "Invalid timelock");
         emit AMOMinterSet(_amo_minter_address);
     }
 

--- a/src/mocks/VaultMock.sol
+++ b/src/mocks/VaultMock.sol
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.6;
+import "@yield-protocol/utils-v2/contracts/token/IERC20.sol";
+import "@yield-protocol/vault-interfaces/src/IFYToken.sol";
+import "@yield-protocol/vault-interfaces/src/DataTypes.sol";
+import "./BaseMock.sol";
+import "./FYTokenMock.sol";
+
+
+interface ILadle {
+    function pour(bytes12 vaultId_, address to, int128 ink, int128 art) external payable;
+    function build(bytes6 seriesId, bytes6 ilkId, uint8 salt) external returns (bytes12 vaultId, DataTypes.Vault memory vault);
+    function cauldron() external view returns (ICauldron);
+}
+
+interface ICauldron {
+    function balances(bytes12 vault) external view returns (DataTypes.Balances memory);
+}
+
+library CauldronMath {
+    /// @dev Add a number (which might be negative) to a positive, and revert if the result is negative.
+    function add(uint128 x, int128 y) internal pure returns (uint128 z) {
+        require (y > 0 || x >= uint128(-y), "Result below zero");
+        z = y > 0 ? x + uint128(y) : x - uint128(-y);
+    }
+}
+
+contract VaultMock is ICauldron, ILadle {
+    using CauldronMath for uint128;
+
+    ICauldron public immutable override cauldron;
+    BaseMock public immutable base;
+    address public immutable baseJoin;  // = address(this)
+    bytes6 public immutable baseId;      // = bytes6(1)
+
+    mapping (bytes6 => DataTypes.Series) public series;
+    mapping (bytes12 => DataTypes.Vault) public vaults;
+    mapping (bytes12 => DataTypes.Balances) public override balances;
+
+    uint96 public lastVaultId;
+    uint48 public nextSeriesId;
+
+    constructor() {
+        cauldron = ICauldron(address(this));
+        base = new BaseMock();
+        baseJoin = address(this);
+        baseId = bytes6(uint48(1));
+    }
+
+    function addSeries(uint32 maturity_) external returns (bytes6) {
+        IFYToken fyToken = IFYToken(address(new FYTokenMock(base, maturity_)));
+        series[bytes6(nextSeriesId++)] = DataTypes.Series({
+            fyToken: fyToken,
+            maturity: maturity_,
+            baseId: baseId
+        });
+
+        return bytes6(nextSeriesId - 1);
+    }
+
+    function build(bytes6 seriesId, bytes6 ilkId, uint8) external override returns (bytes12 vaultId, DataTypes.Vault memory vault) {
+        vaults[bytes12(lastVaultId++)] = DataTypes.Vault({
+            owner: msg.sender,
+            seriesId: seriesId,
+            ilkId: ilkId
+        });
+
+        return (bytes12(lastVaultId - 1), vaults[bytes12(lastVaultId - 1)]);
+    }
+
+    function pour(bytes12 vaultId, address to, int128 ink, int128 art) external override {
+        if (ink > 0) base.burn(address(this), uint128(ink)); // Simulate taking the base, which is also the collateral
+        if (ink < 0) base.mint(to, uint128(-ink));
+        balances[vaultId].ink = balances[vaultId].ink.add(ink);
+        balances[vaultId].art = balances[vaultId].art.add(art);
+        address fyToken = address(series[vaults[vaultId].seriesId].fyToken);
+        if (art > 0) FYTokenMock(fyToken).mint(to, uint128(art));
+        if (art < 0) FYTokenMock(fyToken).burn(fyToken, uint128(-art));
+    }
+}


### PR DESCRIPTION
I extended the AMO to manage several series concurrently.

The code to add and remove series is straightforward, as are the AMO functions that interface with the Yield Protocol.

I stopped short of a full refactor of the views. The signature for `dollarBalances` has no parameters so the balances need to be tallied across series. I implemented a series iterator to make this loop possible, but others might be more qualifies to make sure the math is not broken during the refactor.